### PR TITLE
Add generator pool

### DIFF
--- a/general_test.go
+++ b/general_test.go
@@ -2,9 +2,11 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/Jorropo/generator"
 	"github.com/alphadose/itogami"
 	"github.com/gammazero/workerpool"
 	"github.com/panjf2000/ants/v2"
@@ -88,4 +90,19 @@ func BenchmarkItogamiPool(b *testing.B) {
 		wg.Wait()
 	}
 	b.StopTimer()
+}
+
+func BenchmarkGenerator(b *testing.B) {
+	for i := b.N; i != 0; i-- {
+		var count uint64 = 1<<64 - 1 // start at -1 since atomic.AddUint64 returns the new value (not the old one)
+		p := generator.NewPool(func() (generator.Runner, bool) {
+			i := atomic.AddUint64(&count, 1)
+			if i < RunTimes {
+				return demoFunc, true
+			}
+			return nil, false
+		}, PoolSize)
+
+		p.Wait()
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alphadose/go-threadpool-benchmarks
 go 1.18
 
 require (
+	github.com/Jorropo/generator v0.0.0-20220616120754-5d6e46dcc82c // indirect
 	github.com/alphadose/itogami v0.0.0-20220615140746-2256de286af9 // indirect
 	github.com/gammazero/deque v0.1.0 // indirect
 	github.com/gammazero/workerpool v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Jorropo/generator v0.0.0-20220616120754-5d6e46dcc82c h1:hSg0QTZE20zlP6SGtAHbVFsRLPB1YsvC+pGAQvbVU1Q=
+github.com/Jorropo/generator v0.0.0-20220616120754-5d6e46dcc82c/go.mod h1:7SJu0EPhAyeVonijsVuOFpMO0gV8fa52FXe+CT36Epo=
 github.com/alphadose/itogami v0.0.0-20220615140746-2256de286af9 h1:JxYFFzuDpkqFHm2Fxtz0v+f3YEPTNiRPtWLxVHSRxuc=
 github.com/alphadose/itogami v0.0.0-20220615140746-2256de286af9/go.mod h1:QDsatlDSUJB4sXxZsJEpawGnTDwSdvX27ZXqtuZY3WA=
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=

--- a/vendor/github.com/Jorropo/generator/LICENSE
+++ b/vendor/github.com/Jorropo/generator/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 Jorropo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/Jorropo/generator/gen.go
+++ b/vendor/github.com/Jorropo/generator/gen.go
@@ -1,0 +1,41 @@
+package generator
+
+import "sync"
+
+type Runner func()
+
+type Generator func() (r Runner, ok bool)
+
+type Pool struct {
+	wg sync.WaitGroup
+	g  Generator
+}
+
+func NewPool(g Generator, count int) *Pool {
+	p := &Pool{g: g}
+
+	p.wg.Add(count)
+	for ; count != 0; count-- {
+		go p.pump()
+	}
+
+	return p
+}
+
+func (p *Pool) Wait() {
+	p.wg.Wait()
+}
+
+func (p *Pool) pump() {
+	defer p.wg.Done()
+
+	g := p.g
+
+	for {
+		task, ok := g()
+		if !ok {
+			break
+		}
+		task()
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,6 @@
+# github.com/Jorropo/generator v0.0.0-20220616120754-5d6e46dcc82c
+## explicit; go 1.18
+github.com/Jorropo/generator
 # github.com/alphadose/itogami v0.0.0-20220615140746-2256de286af9
 ## explicit; go 1.18
 github.com/alphadose/itogami


### PR DESCRIPTION
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkUnlimitedGoroutines-12    	       3	 407885944 ns/op	96721301 B/op	 2007116 allocs/op
BenchmarkAntsPool-12               	       2	 779131236 ns/op	20097156 B/op	 1064950 allocs/op
BenchmarkGammaZeroPool-12          	       1	1162897642 ns/op	19343432 B/op	 1057008 allocs/op
BenchmarkItogamiPool-12            	       3	 431012905 ns/op	28744213 B/op	 1051633 allocs/op
BenchmarkGenerator-12              	       5	 230959863 ns/op	 4823598 B/op	  100013 allocs/op
```

It is far faster than other alternatives (including unlimited goroutines).

It allocs far less than other alternatives.

I'll let you benchmark on your arm64 mac m1 but results will hold there too.

---

Main reasons it's faster than itogami:
- Itogami has an optimised scheduling interaction calling directly into the runtime. (which is UB and can break at any moment)
  - Generator just say: "what if I doesn't schedule in the first place ?"
- Itogami has an optimised task queue.
  - Generator just say: "what if I doesn't have a task queue and I ask you for more work instead ?"